### PR TITLE
Ubt20: Fix compilation error and runtime error

### DIFF
--- a/cpp/io_depth.h
+++ b/cpp/io_depth.h
@@ -106,7 +106,7 @@ public:
   }
 
   // is depth at given pixel to invalid
-  inline bool setInvalid (const int32_t u,const int32_t v) {
+  inline void setInvalid (const int32_t u,const int32_t v) {
     data_[v*width_+u] = -1;
   }
 
@@ -241,7 +241,7 @@ public:
               }
             }
           } else {
-            float d_err = std::min(fabs(getDepth(u,v)-D_gt.getDepth(u,v)),5.0)/5.0;
+            float d_err = std::min(fabs(getDepth(u,v)-D_gt.getDepth(u,v)),5.0f)/5.0f;
             val.red   = (uint8_t)(d_err*255.0);
             val.green = (uint8_t)(d_err*255.0);
             val.blue  = (uint8_t)(d_err*255.0);


### PR DESCRIPTION
L244 compilation error:
```
io_depth.h:244:78: error: no matching function for call to 'min(float, double)'
  244 |             float d_err = std::min(fabs(getDepth(u,v)-D_gt.getDepth(u,v)),5.0)/5.0;
      |
```

L109 runtime error
```
Starting depth evaluation..
Found 1000 groundtruth and 1000 prediction files!
Processing: 2011_09_26_drive_0002_sync_groundtruth_depth_0000000005_image_02
Segmentation fault
```